### PR TITLE
Dodano podstawowe wyświetlanie listy roślin na stronie głównej

### DIFF
--- a/frontend/app/src/main/java/com/example/planttrackerapp/MainPlantScreen.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/MainPlantScreen.kt
@@ -51,8 +51,8 @@ fun PlantApp(
         ) {
             composable(route = PlantAppScreen.AllPlants.name) {
                 PlantList(
-                    onClickA = { navController.navigate(PlantAppScreen.PlantDetails.name) },
-                    onClickB = { navController.navigate(PlantAppScreen.Form.name) }
+                    onClickB = { navController.navigate(PlantAppScreen.Form.name) },
+                    onClick = { navController.navigate(PlantAppScreen.PlantDetails.name) }
                 )
             }
 

--- a/frontend/app/src/main/java/com/example/planttrackerapp/ui/PlantList.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/ui/PlantList.kt
@@ -2,37 +2,51 @@ package com.example.planttrackerapp.ui
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.example.planttrackerapp.data.Datasource
+import com.example.planttrackerapp.model.Plant
+import com.example.planttrackerapp.ui.components.SinglePlantCard
 
 @Composable
 fun PlantList(
-    onClickA: () -> Unit = {},
+    // onClickA: () -> Unit = {},
     onClickB: () -> Unit = {},
+    onClick: (Plant) -> Unit,
     modifier: Modifier = Modifier
 ){
-    Column {
-        Text(
-            text = "PlantApp"
-        )
-        Button(
-            onClick = {
-                onClickA()
-            }
-        ) {
-            Text(
-                text = "A"
-            )
-        }
-        Button(
-            onClick = { onClickB() }
-        ) {
-            Text(
-                text = "B"
-            )
+//    Column {
+//        Text(
+//            text = "PlantApp"
+//        )
+//        Button(
+//            onClick = {
+//                onClickA()
+//            }
+//        ) {
+//            Text(
+//                text = "A"
+//            )
+//        }
+//        Button(
+//            onClick = { onClickB() }
+//        ) {
+//            Text(
+//                text = "B"
+//            )
+//        }
+//    }
+// Trzeba dodać do roślin onClick żeby dało się przechodzić do ich detali (SinglePlantView)
+    val plants = Datasource.plantList
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(plants.size) { index ->
+            SinglePlantCard(
+                plant = plants[index],
+                onItemClick = onClick)
         }
     }
-
 }

--- a/frontend/app/src/main/java/com/example/planttrackerapp/ui/components/SinglePlantCard.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/ui/components/SinglePlantCard.kt
@@ -5,7 +5,9 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.example.planttrackerapp.data.Datasource
 import com.example.planttrackerapp.model.Plant
 
 @Composable
@@ -34,4 +36,13 @@ fun SinglePlantCard(
             )
         }
     }
+}
+
+@Preview(showBackground=true)
+@Composable
+fun PreviewSingleCard(){
+    SinglePlantCard(
+        plant = Datasource.plantList[0],
+        onItemClick = {}
+    )
 }

--- a/frontend/app/src/main/java/com/example/planttrackerapp/ui/components/SinglePlantCard.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/ui/components/SinglePlantCard.kt
@@ -1,2 +1,37 @@
 package com.example.planttrackerapp.ui.components
 
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.example.planttrackerapp.model.Plant
+
+@Composable
+fun SinglePlantCard(
+    plant: Plant,
+    onItemClick: (Plant) -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        elevation = CardDefaults.cardElevation(4.dp),
+        onClick = { onItemClick(plant) }
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = plant.name,
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Species: ${plant.species.name}",
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}


### PR DESCRIPTION
Wyświetlanie listy. Elementy da się kliknąć, w następnym branchu będę ogarniać widok detali dla poszczególnych roślin.

Modifiery narazie są zakodowane w komponencie, w jakimś kolejnym issue przeniosę wszystkie elementy związane z wyglądem do osobnych plików, żeby były reusable.

Trzeba przetestować, czy lista jest reaktywna (czy nowe pozycje wyświetlają się po dodaniu ich).

