### PR TITLE
141 poprawki wizualne

### DIFF
--- a/frontend/app/src/main/java/com/example/planttrackerapp/MainPlantScreen.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/MainPlantScreen.kt
@@ -91,8 +91,11 @@ fun PlantApp(
                     PlantAppScreen.Form.name -> "Add A New Plant"
                     PlantAppScreen.FormEdit.name -> "Edit Plant"
                     PlantAppScreen.PlantJournal.name -> "Plant Journal"
-                    PlantAppScreen.ActivityJournal.name -> "${currentPlantState.currentlyEditedPlant?.name}'s journal"
+                    PlantAppScreen.ActivityJournal.name -> "${currentPlantState.currentlyEditedPlant?.name}'s Journal"
                     PlantAppScreen.AllSpecies.name -> "My Species"
+                    PlantAppScreen.AddDisease.name -> "Document Event"
+                    PlantAppScreen.AddRepot.name -> "Document Event"
+                    PlantAppScreen.AddOther.name -> "Document Event"
                     else -> "Plant Tracker"
                 },
                 canNavigateBack = canNavigateBack,

--- a/frontend/app/src/main/java/com/example/planttrackerapp/ui/ActionForm.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/ui/ActionForm.kt
@@ -1,9 +1,18 @@
 package com.example.planttrackerapp.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -23,38 +32,84 @@ fun ActionForm(
     isDisease: Boolean,
     onSubmit: KFunction2<String, String, Unit>,
     onGoBack: () -> Unit
-){
+) {
     var text by remember { mutableStateOf("") }
-    val option = if (isRepot) {"new repot (soil type, pot size...)"}
-    else if(isDisease){"disease"}
-    else{"other"}
 
-    Column {
-       Text("Document a new ${option}")
-        TextField(
-            value = text,
-            onValueChange = {
-                text = it
-            },
-            label = {Text(option)},
-            colors = TextFieldDefaults.colors(
-                unfocusedIndicatorColor = Color.Transparent,
-                focusedIndicatorColor = Color.Transparent
-            ),
-            shape = RoundedCornerShape(16.dp),
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
+    val option = when {
+        isRepot -> "a new repot"
+        isDisease -> "a new disease"
+        else -> "something else"
+    }
 
-        Button(
-            onClick = {
-                val funOption = if (isRepot) "repot"
-                else if (isDisease) "disease"
-                else "other"
-                onSubmit( text, funOption)
-                onGoBack()
-            }
+    val label = when {
+        isRepot -> "Repot details"
+        isDisease -> "Disease description"
+        else -> "Additional info"
+    }
+
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        shadowElevation = 8.dp,
+        tonalElevation = 4.dp,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(24.dp)
         ) {
-            Text("Add")
+            Text(
+                text = "Document ${option}",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            TextField(
+                value = text,
+                onValueChange = { text = it },
+                label = { Text(label) },
+                placeholder = { Text("Enter details...") },
+                shape = RoundedCornerShape(12.dp),
+                singleLine = false,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 100.dp)
+                    .padding(bottom = 16.dp),
+                colors = TextFieldDefaults.colors(
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                )
+            )
+
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedButton(
+                    onClick = onGoBack,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Cancel")
+                }
+
+                Spacer(modifier = Modifier.width(16.dp))
+
+                Button(
+                    onClick = {
+                        val funOption = when {
+                            isRepot -> "repot"
+                            isDisease -> "disease"
+                            else -> "other"
+                        }
+                        onSubmit(text, funOption)
+                        onGoBack()
+                    },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Add")
+                }
+            }
         }
     }
 }

--- a/frontend/app/src/main/java/com/example/planttrackerapp/ui/PlantForm.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/ui/PlantForm.kt
@@ -4,11 +4,15 @@ import android.net.Uri
 import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -51,79 +55,74 @@ fun PlantForm(
     onUpdateSpeciesValue: (Species?) -> Unit = {},
     isEdit: Boolean = false,
     modifier: Modifier = Modifier
-){
+) {
     resetForm()
     Log.d(TAG, "Current Plant Data: ${currentPlantData}")
-   LazyColumn (
-       modifier = Modifier.fillMaxWidth(),
-       horizontalAlignment = Alignment.CenterHorizontally
-   ){
-    item {
-        if (isEdit){
-            Text(
-                modifier = Modifier.padding(16.dp),
-                fontWeight = FontWeight.Bold,
-                fontSize = 24.sp,
-                text = "Edit specimen"
-            )
-        } else{
-            Text(
-                modifier = Modifier.padding(16.dp),
-                fontWeight = FontWeight.Bold,
-                fontSize = 24.sp,
-                text = "Add specimen"
-            )
-        }
 
-
-        FormBody(
-            isEdit = isEdit,
-            currentPlantData = currentPlantData,
-            speciesList = speciesList,
-            onEditSpeciesValue = onEditSpeciesValue,
-            onUploadImage = onUploadImage,
-            onEditNameValue = onEditNameValue,
-            onUpdateNameValue = onUpdateNameValue,
-            onUpdateSpeciesValue = onUpdateSpeciesValue,
-            modifier = modifier
-        )
-
-        Row{
-            if(isEdit){
-                Button(
-                    modifier = Modifier.padding(top = 16.dp),
-                    onClick = {
-                        onClickEdit()
-                        onGoBack()
-                    }
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        item {
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                tonalElevation = 4.dp,
+                shadowElevation = 8.dp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .padding(24.dp)
+                        .fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     Text(
-                        text = "Edit"
+                        text = if (isEdit) "Edit specimen" else "Add specimen",
+                        style = MaterialTheme.typography.headlineSmall,
+                        modifier = Modifier.padding(bottom = 16.dp)
                     )
-                }
-            } else {
-                Button(
-                    modifier = Modifier.padding(top = 16.dp),
-                    onClick = {
-                        Log.d("add", "formViewModel: $formViewModel")
-                        formViewModel?.onClickAdd {
-                            Log.d("add", "onadd")
-                            onGoBack()
+
+                    FormBody(
+                        isEdit = isEdit,
+                        currentPlantData = currentPlantData,
+                        speciesList = speciesList,
+                        onEditSpeciesValue = onEditSpeciesValue,
+                        onUploadImage = onUploadImage,
+                        onEditNameValue = onEditNameValue,
+                        onUpdateNameValue = onUpdateNameValue,
+                        onUpdateSpeciesValue = onUpdateSpeciesValue,
+                        modifier = modifier
+                    )
+
+                    Button(
+                        modifier = Modifier
+                            .padding(top = 28.dp)
+                            .fillMaxWidth(),
+                        onClick = {
+                            if (isEdit) {
+                                onClickEdit()
+                                onGoBack()
+                            } else {
+                                Log.d("add", "formViewModel: $formViewModel")
+                                formViewModel?.onClickAdd {
+                                    Log.d("add", "onadd")
+                                    onGoBack()
+                                }
+                            }
                         }
+                    ) {
+                        Text(text = if (isEdit) "Edit" else "Add")
                     }
-                ) {
-                    Text(
-                        text = "Add"
-                    )
                 }
             }
-
         }
     }
-
-
-   }
 }
+
 
 @Composable
 fun FormBody(
@@ -136,50 +135,44 @@ fun FormBody(
     onUpdateNameValue: (String?) -> Unit = {},
     onUpdateSpeciesValue: (Species?) -> Unit = {},
     modifier: Modifier = Modifier
-){
+) {
     val name = currentPlantData?.name ?: ""
     var plantName by remember { mutableStateOf(name) }
-    val funToBePassed =
-        if (isEdit) onEditSpeciesValue
-        else onUpdateSpeciesValue
+    val speciesCallback = if (isEdit) onEditSpeciesValue else onUpdateSpeciesValue
 
-    Column (
+    Column(
         modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        ImageField(
+            onUploadImage = onUploadImage,
+            plant = currentPlantData
+        )
 
-    ){
-            ImageField(
-                onUploadImage = onUploadImage,
-                plant = currentPlantData
+        TextField(
+            value = plantName,
+            onValueChange = {
+                plantName = it
+                if (isEdit) onEditNameValue(it)
+                else onUpdateNameValue(it)
+            },
+            label = { Text("Name of plant") },
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier
+                .padding(bottom = 16.dp),
+            colors = TextFieldDefaults.colors(
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent
             )
-            TextField(
-                value = plantName,
-                onValueChange = {
-                    plantName = it
-                    if (isEdit){
-                        onEditNameValue(it)
-                    } else {
-                        onUpdateNameValue(it)
-                    }
-                },
-                label = {Text("Name of plant")},
-                colors = TextFieldDefaults.colors(
-                    unfocusedIndicatorColor = Color.Transparent,
-                    focusedIndicatorColor = Color.Transparent
-                ),
-                shape = RoundedCornerShape(16.dp),
-                modifier = Modifier.padding(bottom = 8.dp)
-            )
+        )
 
-            DropDownWrapper(
-                items = speciesList,
-                onUpdateValue = funToBePassed,
-                label = "Species"
-            )
-        }
-
+        DropDownWrapper(
+            items = speciesList,
+            onUpdateValue = speciesCallback,
+            label = "Species",
+        )
+    }
 }
-
 
 
 @Preview(showBackground = true)

--- a/frontend/app/src/main/java/com/example/planttrackerapp/ui/SinglePlantView.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/ui/SinglePlantView.kt
@@ -280,7 +280,7 @@ fun SinglePlantView(
                         .fillMaxWidth(0.8f)
                         .padding(vertical = 4.dp)
                 ) {
-                    Text("Note other event")
+                    Text("Note something else")
                 }
             }
         }

--- a/frontend/app/src/main/java/com/example/planttrackerapp/ui/SinglePlantView.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/ui/SinglePlantView.kt
@@ -40,6 +40,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.ui.Alignment
@@ -237,12 +238,12 @@ fun SinglePlantView(
         }
 
         Spacer(modifier = Modifier.height(16.dp))
-
-        Card(
+        Surface(
             shape = RoundedCornerShape(16.dp),
+            tonalElevation = 4.dp,
+            shadowElevation = 8.dp,
             modifier = Modifier
-                .fillMaxWidth(),
-            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+                .fillMaxWidth()
         ) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/frontend/app/src/main/java/com/example/planttrackerapp/ui/SinglePlantView.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/ui/SinglePlantView.kt
@@ -31,18 +31,23 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import com.example.planttrackerapp.backend.database.base64ToBitmap
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontStyle
 import coil3.compose.AsyncImage
 import com.example.planttrackerapp.R
 import kotlin.reflect.KFunction1
+import androidx.core.net.toUri
 
 
 @Composable
@@ -72,44 +77,72 @@ fun SinglePlantView(
             .verticalScroll(rememberScrollState())
     ) {
 
-        val plantImage = painterResource(R.drawable.imgbig)
-        if(plant?.imageUri != null){
-            AsyncImage(
-                model = Uri.parse(plant.imageUri),
-                contentDescription = plant.imageUri,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .width(82.dp)
-                    .height(117.dp)
-            )
-        }
-        else{
-            Image(
-                painter = plantImage,
-                contentDescription = null
-            )
-        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            val plantImage = painterResource(R.drawable.imgbig)
+            if (plant?.imageUri != null) {
+                AsyncImage(
+                    model = plant.imageUri.toUri(),
+                    contentDescription = plant.imageUri,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .width(100.dp)
+                        .height(140.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                )
+            } else {
+                Image(
+                    painter = plantImage,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .width(100.dp)
+                        .height(140.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                )
+            }
 
-        Text(
-            text = plant?.name ?: "",
-            style = androidx.compose.material3.MaterialTheme.typography.titleLarge
-        )
+            Spacer(modifier = Modifier.width(16.dp))
 
-        Button(onClick = onGoToActivityJournal) {
-            Text(text = "See plant journal")
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = plant?.name ?: "",
+                    style = MaterialTheme.typography.titleLarge
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Text(
+                    text = plant?.species?.name ?: "",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontStyle = FontStyle.Italic
+                    )
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row {
+                    Button(onClick = onGoToActivityJournal) {
+                        Text("Journal")
+                    }
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    Button(onClick = onGoToForm) {
+                        Text("Edit")
+                    }
+                }
+            }
         }
 
         Spacer(modifier = Modifier.height(16.dp))
 
         Text(
-            text = "Species: ${plant?.species?.name ?: ""}",
-            style = androidx.compose.material3.MaterialTheme.typography.bodyMedium
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        Text(
-            text = "Soil Moisture Level: ${plant?.species?.soilMoisture ?: ""}",
+            text = "Recommended soil moisture level: ${plant?.species?.soilMoisture ?: ""}",
             style = androidx.compose.material3.MaterialTheme.typography.bodyMedium
         )
 
@@ -122,40 +155,18 @@ fun SinglePlantView(
 
         if (date != null) {
             Text(
-                text = "Created On: ${formatDate(date)}",
+                text = "Created: ${formatDate(date)}",
                 style = androidx.compose.material3.MaterialTheme.typography.bodyMedium
             )
             Spacer(modifier = Modifier.height(8.dp))
         }
         if (watered != null) {
             Text(
-                text = "Last Watered: ${formatDate(watered)}",
+                text = "Last watered: ${formatDate(watered)}",
                 style = androidx.compose.material3.MaterialTheme.typography.bodyMedium
             )
         }
         Spacer(modifier = Modifier.height(16.dp))
-
-        // QR Code section
-        plant?.qrCodeImage?.let { qrCodeBase64 ->
-            val qrBitmap = remember { base64ToBitmap(qrCodeBase64) }
-
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = "QR Code:",
-                style = androidx.compose.material3.MaterialTheme.typography.bodyMedium
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Display the QR code bitmap
-            Image(
-                bitmap = qrBitmap.asImageBitmap(),
-                contentDescription = "QR Code for ${plant.name}",
-                modifier = Modifier
-                    .size(200.dp)
-
-            )
-        }
 
         Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
             TextField(
@@ -163,14 +174,14 @@ fun SinglePlantView(
                 onValueChange = {
                     fertilizer = it
                 },
-                label = {Text("fertilizer")},
+                label = {Text("Add fertilizer")},
                 colors = TextFieldDefaults.colors(
                     unfocusedIndicatorColor = Color.Transparent,
                     focusedIndicatorColor = Color.Transparent
                 ),
                 shape = RoundedCornerShape(16.dp),
                 modifier = Modifier
-                    .padding(bottom = 8.dp, end = 4.dp, top = 8.dp)
+                    .padding(bottom = 8.dp, end = 16.dp)
                     .fillMaxWidth(0.4f)
             )
             Button(onClick = {
@@ -205,24 +216,17 @@ fun SinglePlantView(
             Button(
                 onClick = {onGoToRepot()}
             ) {
-                Text("Repot")
+                Text("Note repot")
             }
             Button(
                 onClick = {onGoToDisease()}
             ) {
-                Text("Disease")
+                Text("Note disease")
             }
             Button(
                 onClick = {onGoToOther()}
             ) {
-                Text("Other")
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-
-            Button(onClick = onGoToForm) {
-                Text(text = "Edit plant")
+                Text("Note other event")
             }
 
             Button(onClick = { showPopUp = !showPopUp }) {
@@ -253,21 +257,12 @@ fun SinglePlantView(
                 }
             )
         }
+
     }
 
 
 
 fun formatDate(calendar: java.util.Calendar): String {
-    val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+    val formatter = SimpleDateFormat("HH:mm, MMM dd yyyy", Locale.getDefault())
     return formatter.format(calendar.time)
 }
-
-//@Preview(showBackground = true)
-//@Composable
-//fun SinglePlantPreview(modifier: Modifier = Modifier) {
-//    PlantTrackerAppTheme {
-//        SinglePlantView(
-//            plant = Datasource.plantList[1], onGoBack = {}, onGoToActivityJournal = {},
-//            onWater = , onGoToForm = {}, onClickYes = {})
-//    }
-//}

--- a/frontend/app/src/main/java/com/example/planttrackerapp/ui/SinglePlantView.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/ui/SinglePlantView.kt
@@ -6,7 +6,9 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -35,6 +37,9 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.ui.Alignment
@@ -151,7 +156,7 @@ fun SinglePlantView(
         val date = plant?.created
         val watered = plant?.waterHistory
             ?.flatMap { it.values }
-            ?.maxByOrNull { it.timeInMillis}
+            ?.maxByOrNull { it.timeInMillis }
 
         if (date != null) {
             Text(
@@ -167,73 +172,132 @@ fun SinglePlantView(
             )
         }
         Spacer(modifier = Modifier.height(16.dp))
-
-        Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+        Column(
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+        ) {
             TextField(
                 value = fertilizer,
                 onValueChange = {
                     fertilizer = it
                 },
-                label = {Text("Add fertilizer")},
+                label = { Text("Fertilizer (optional)") },
                 colors = TextFieldDefaults.colors(
                     unfocusedIndicatorColor = Color.Transparent,
                     focusedIndicatorColor = Color.Transparent
                 ),
                 shape = RoundedCornerShape(16.dp),
                 modifier = Modifier
-                    .padding(bottom = 8.dp, end = 16.dp)
-                    .fillMaxWidth(0.4f)
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp)
             )
-            Button(onClick = {
-                showWateredMessage = true
-                onWater(fertilizer)
-                fertilizer = ""
-            }) {
+
+            Button(
+                onClick = {
+                    showWateredMessage = true
+                    onWater(fertilizer)
+                    fertilizer = ""
+                },
+                modifier = Modifier
+                    .wrapContentWidth()
+            ) {
                 Text(text = "Water plant")
             }
 
-                Spacer(modifier = Modifier.width(8.dp))
-
-                AnimatedVisibility(
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(28.dp) // reserve space
+                    .padding(top = 8.dp),
+                contentAlignment = Alignment.TopCenter
+            ) {
+                androidx.compose.animation.AnimatedVisibility(
                     visible = showWateredMessage,
-                    enter = fadeIn() + slideInHorizontally(initialOffsetX = { -it / 8 }),
-                    exit = fadeOut() + slideOutHorizontally(targetOffsetX = { -it / 8 })
+                    enter = slideInVertically(initialOffsetY = { -it / 2 }) + fadeIn(),
+                    exit = slideOutVertically(targetOffsetY = { -it / 2 }) + fadeOut()
                 ) {
                     Text(
                         text = "Plant watered!",
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.secondary,
+                        color = MaterialTheme.colorScheme.secondary
                     )
                 }
+            }
 
-                if (showWateredMessage) {
-                    LaunchedEffect(Unit) {
-                        delay(2000) // 2 seconds
-                        showWateredMessage = false
-                    }
+
+            if (showWateredMessage) {
+                LaunchedEffect(Unit) {
+                    delay(2000)
+                    showWateredMessage = false
                 }
             }
-            Button(
-                onClick = {onGoToRepot()}
-            ) {
-                Text("Note repot")
-            }
-            Button(
-                onClick = {onGoToDisease()}
-            ) {
-                Text("Note disease")
-            }
-            Button(
-                onClick = {onGoToOther()}
-            ) {
-                Text("Note other event")
-            }
 
-            Button(onClick = { showPopUp = !showPopUp }) {
-                Text(text = "Delete plant")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier
+                .fillMaxWidth(),
+            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = "${plant?.name}'s events",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(bottom = 12.dp)
+                )
+
+                Button(
+                    onClick = { onGoToRepot() },
+                    modifier = Modifier
+                        .fillMaxWidth(0.8f)
+                        .padding(vertical = 4.dp)
+                ) {
+                    Text("Note repot")
+                }
+
+                Button(
+                    onClick = { onGoToDisease() },
+                    modifier = Modifier
+                        .fillMaxWidth(0.8f)
+                        .padding(vertical = 4.dp)
+                ) {
+                    Text("Note disease")
+                }
+
+                Button(
+                    onClick = { onGoToOther() },
+                    modifier = Modifier
+                        .fillMaxWidth(0.8f)
+                        .padding(vertical = 4.dp)
+                ) {
+                    Text("Note other event")
+                }
             }
         }
 
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = { showPopUp = !showPopUp },
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.error,
+                contentColor = MaterialTheme.colorScheme.onError
+            ),
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+        ) {
+            Text("Delete plant")
+        }
 
 
         if (showPopUp) {
@@ -257,7 +321,7 @@ fun SinglePlantView(
                 }
             )
         }
-
+    }
     }
 
 

--- a/frontend/app/src/main/java/com/example/planttrackerapp/ui/components/ImageField.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/ui/components/ImageField.kt
@@ -8,17 +8,34 @@ import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -42,20 +59,20 @@ fun copyImageToInternalStorage(context: Context, sourceUri: Uri, filename: Strin
         null
     }
 }
-
-
 @SuppressLint("SuspiciousIndentation")
 @Composable
 fun ImageField(
     onUploadImage: (Uri?) -> Unit,
     plant: Plant? = null,
     modifier: Modifier = Modifier
-){
+) {
     val context = LocalContext.current
     var startingVal: Uri? = null
-    if(plant?.imageUri != null){
+
+    if (plant?.imageUri != null) {
         startingVal = Uri.parse(plant.imageUri)
     }
+
     var selectedImageUri by remember {
         mutableStateOf<Uri?>(startingVal)
     }
@@ -76,40 +93,66 @@ fun ImageField(
                     Log.d(TAG, "Obrazek skopiowany do ścieżki: ${pathToImage}")
                     onUploadImage(Uri.fromFile(File(pathToImage)))
                 }
-                    selectedImageUri = Uri.fromFile(File(pathToImage))
-                } else {
-                    Log.e(TAG, "Nie udało się skopiować obrazka")
-                }
+                selectedImageUri = Uri.fromFile(File(pathToImage))
+            } else {
+                Log.e(TAG, "Nie udało się skopiować obrazka")
             }
+        }
     )
-        AsyncImage(
-            model = selectedImageUri?.let { uri ->
-                if (uri.scheme == "file") File(uri.path) else uri
-            },
-            contentDescription = "",
-            modifier = Modifier
-                .width(228.dp)
-                .height(324.dp)
-        )
 
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(bottom = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        selectedImageUri?.let { uri ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(), // allow centering
+                contentAlignment = Alignment.Center
+            ) {
+                AsyncImage(
+                    model = if (uri.scheme == "file") File(uri.path) else uri,
+                    contentDescription = "Selected image",
+                    modifier = Modifier
+                        .width(220.dp)
+                        .aspectRatio(10f / 14f)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(Color.LightGray),
+                    contentScale = ContentScale.Crop
+                )
+            }
 
-    Row(modifier = Modifier){
-        Button(onClick = {
-            singleImagePickerLauncher.launch(
-                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-            )
-        }) {
-            Text("Choose image")
+            Spacer(modifier = Modifier.height(16.dp))
         }
 
-        Button(onClick = {
-            selectedImageUri = null
-            onUploadImage(selectedImageUri)
-        }) {
-            Text("Clear image")
+
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Button(
+                onClick = {
+                    singleImagePickerLauncher.launch(
+                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                    )
+                },
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Choose image")
+            }
+
+            OutlinedButton(
+                onClick = {
+                    selectedImageUri = null
+                    onUploadImage(null)
+                },
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Clear image")
+            }
         }
     }
-
-
-
 }

--- a/frontend/app/src/main/java/com/example/planttrackerapp/ui/components/SinglePlantCard.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/ui/components/SinglePlantCard.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -56,16 +57,17 @@ fun SinglePlantCard(
                 )
 
             }
-
-            Column(modifier = Modifier.padding(start = 4.dp)) {
+            Column(modifier = Modifier.padding(start = 16.dp)) {
                 Text(
                     text = plant.name,
                     style = MaterialTheme.typography.titleMedium
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = "Species: ${plant.species?.name ?: "unknown"}",
-                    style = MaterialTheme.typography.bodyMedium,
+                    text = plant.species?.name ?: "unknown",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontStyle = FontStyle.Italic
+                    ),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )

--- a/frontend/app/src/main/java/com/example/planttrackerapp/ui/components/SinglePlantCard.kt
+++ b/frontend/app/src/main/java/com/example/planttrackerapp/ui/components/SinglePlantCard.kt
@@ -1,14 +1,12 @@
 package com.example.planttrackerapp.ui.components
 
 import android.net.Uri
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
@@ -16,9 +14,25 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.example.planttrackerapp.R
-import com.example.planttrackerapp.TAG
 import com.example.planttrackerapp.data.Datasource
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
 import com.example.planttrackerapp.model.Plant
+
+
 
 @Composable
 fun SinglePlantCard(
@@ -26,8 +40,8 @@ fun SinglePlantCard(
     onItemClick: (Plant) -> Unit,
     onSetPlant: (Plant) -> Unit
 ) {
-
     val image = painterResource(R.drawable.imgsmall)
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -38,25 +52,33 @@ fun SinglePlantCard(
             onItemClick(plant)
         }
     ) {
-        Row(modifier = Modifier.padding(16.dp)){
-            if(plant.imageUri != null){
-                AsyncImage(
-                    model = Uri.parse(plant.imageUri),
-                    contentDescription = plant.imageUri,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .width(30.dp)
-                        .height(43.dp)
-
-
-                )
-            } else {
-                Image(
-                    painter = image,
-                    contentDescription = null,
-                )
+        Row(modifier = Modifier.padding(16.dp)) {
+            Box(
+                modifier = Modifier
+                    .size(width = 60.dp, height = 80.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color.LightGray)
+            ) {
+                if (plant.imageUri != null) {
+                    AsyncImage(
+                        model = Uri.parse(plant.imageUri),
+                        contentDescription = plant.imageUri,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .matchParentSize()
+                    )
+                } else {
+                    Image(
+                        painter = image,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .matchParentSize()
+                    )
+                }
 
             }
+
             Column(modifier = Modifier.padding(start = 16.dp)) {
                 Text(
                     text = plant.name,


### PR DESCRIPTION
Poprawiłam wygląd niektórych komponentów:
- Plant List - większe obrazki, gatunki zapisane kursywą
- Plant Details - nazwa rośliny, przyciski Journal i Edit są teraz obok obrazka, reszta przycisków wycentrowana, osobna sekcja z dodawaniem wydarzeń, czerwony przycisk Delete
- formularze - obiekty Surface dla lepszej czytelności, miejsce na obraz pojawia się dopiero jeśli obraz zostanie dodany, ładniejsze przyciski
- skaner kodów QR - skopiowany nowy wygląd podlewania z Plant Details